### PR TITLE
feat: update deps, add new methods, replace deprecation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbdc-pool-deadpool"
-version = "4.5.7"
+version = "4.7.0"
 edition = "2021"
 description = "The Rust SQL Toolkit and ORM Library. An async, pure Rust SQL crate featuring compile-time Dynamic SQL"
 readme = "readme.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://rbatis.github.io/rbatis.io"
 
 [dependencies]
 async-trait = "0.1"
-# futures-core = { version = "0.3" }
-rbs = { version = "4.5" }
-rbdc = { version = "4.5",default-features = false }
-deadpool = { version = "0.12" }
+rbs = { version = "4.7" }
+rbdc = { version = "4.7", default-features = false }
+deadpool = { version = "0.13" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,18 @@
+use std::fmt::{Debug, Formatter};
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
 use async_trait::async_trait;
 use deadpool::managed::{Metrics, Object, RecycleError, RecycleResult, Timeouts};
 use deadpool::Status;
-// use futures_core::future::BoxFuture;
 use rbdc::db::{Connection, ExecResult, Row};
-use rbdc::pool::conn_box::ConnectionBox;
-use rbdc::pool::conn_manager::ConnManager;
-use rbdc::pool::Pool;
-use rbdc::{db, Error};
+use rbdc::pool::{ConnectionGuard, ConnectionManager, Pool};
+use rbdc::Error;
 use rbs::value::map::ValueMap;
-use rbs::{to_value, Value};
-use std::fmt::{Debug, Formatter};
-use std::time::Duration;
+use rbs::{value, Value};
+
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 pub struct DeadPool {
     pub manager: ConnManagerProxy,
@@ -36,7 +38,7 @@ impl DeadPool {
 
 #[async_trait]
 impl Pool for DeadPool {
-    fn new(manager: ConnManager) -> Result<Self, Error>
+    fn new(manager: ConnectionManager) -> Result<Self, Error>
     where
         Self: Sized,
     {
@@ -57,7 +59,11 @@ impl Pool for DeadPool {
     }
 
     async fn get(&self) -> Result<Box<dyn Connection>, Error> {
-        let v = self.inner.get().await.map_err(|e| Error::from(e.to_string()))?;
+        let v = self
+            .inner
+            .get()
+            .await
+            .map_err(|e| Error::from(e.to_string()))?;
         let conn = ConnManagerProxy {
             inner: v.manager_proxy.clone(),
             conn: Some(v),
@@ -66,10 +72,16 @@ impl Pool for DeadPool {
     }
 
     async fn get_timeout(&self, d: Duration) -> Result<Box<dyn Connection>, Error> {
-        let mut out = Timeouts::default();
-        out.create = Some(d);
-        out.wait = Some(d);
-        let v = self.inner.timeout_get(&out).await.map_err(|e| Error::from(e.to_string()))?;
+        let out = Timeouts {
+            create: Some(d),
+            wait: Some(d),
+            recycle: None,
+        };
+        let v = self
+            .inner
+            .timeout_get(&out)
+            .await
+            .map_err(|e| Error::from(e.to_string()))?;
         let conn = ConnManagerProxy {
             inner: v.manager_proxy.clone(),
             conn: Some(v),
@@ -96,30 +108,41 @@ impl Pool for DeadPool {
     async fn state(&self) -> Value {
         let mut m = ValueMap::with_capacity(10);
         let state = self.status();
-        m.insert(to_value!("max_size"), to_value!(state.max_size));
-        m.insert(to_value!("size"), to_value!(state.size));
-        m.insert(to_value!("available"), to_value!(state.available));
-        m.insert(to_value!("waiting"), to_value!(state.waiting));
+        m.insert(value!("max_size"), value!(state.max_size));
+        m.insert(value!("size"), value!(state.size));
+        m.insert(value!("available"), value!(state.available));
+        m.insert(value!("waiting"), value!(state.waiting));
         Value::Map(m)
     }
 }
 
 pub struct ConnManagerProxy {
-    pub inner: ConnManager,
+    pub inner: ConnectionManager,
     pub conn: Option<Object<ConnManagerProxy>>,
 }
 
-// #[async_trait]
-impl deadpool::managed::Manager for ConnManagerProxy {
-    type Type = ConnectionBox;
+impl From<ConnectionManager> for ConnManagerProxy {
+    fn from(value: ConnectionManager) -> Self {
+        ConnManagerProxy {
+            inner: value,
+            conn: None,
+        }
+    }
+}
 
+impl deadpool::managed::Manager for ConnManagerProxy {
+    type Type = ConnectionGuard;
     type Error = Error;
 
     async fn create(&self) -> Result<Self::Type, Self::Error> {
         self.inner.connect().await
     }
 
-    async fn recycle(&self, obj: &mut Self::Type, _metrics: &Metrics) -> RecycleResult<Self::Error> {
+    async fn recycle(
+        &self,
+        obj: &mut Self::Type,
+        _metrics: &Metrics,
+    ) -> RecycleResult<Self::Error> {
         if obj.conn.is_none() {
             return Err(RecycleError::Message("none".into()));
         }
@@ -128,37 +151,60 @@ impl deadpool::managed::Manager for ConnManagerProxy {
     }
 }
 
-use std::future::Future;
-use std::pin::Pin;
-pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
-
-impl db::Connection for ConnManagerProxy {
-    fn get_rows(&mut self, sql: &str, params: Vec<Value>) -> BoxFuture<Result<Vec<Box<dyn Row>>, Error>> {
+impl Connection for ConnManagerProxy {
+    fn get_rows(
+        &mut self,
+        sql: &str,
+        params: Vec<Value>,
+    ) -> BoxFuture<'_, Result<Vec<Box<dyn Row>>, Error>> {
         if self.conn.is_none() {
-            return Box::pin(async { Err(Error::from("conn is drop")) });
+            return Box::pin(async {
+                Err::<Vec<Box<dyn Row>>, Error>(Error::from("conn is drop"))
+            });
         }
         self.conn.as_mut().unwrap().get_rows(sql, params)
     }
 
-    fn exec(&mut self, sql: &str, params: Vec<Value>) -> BoxFuture<Result<ExecResult, Error>> {
+    fn exec(&mut self, sql: &str, params: Vec<Value>) -> BoxFuture<'_, Result<ExecResult, Error>> {
         if self.conn.is_none() {
             return Box::pin(async { Err(Error::from("conn is drop")) });
         }
         self.conn.as_mut().unwrap().exec(sql, params)
     }
 
-    fn ping(&mut self) -> BoxFuture<Result<(), Error>> {
+    fn ping(&mut self) -> BoxFuture<'_, Result<(), Error>> {
         if self.conn.is_none() {
             return Box::pin(async { Err(Error::from("conn is drop")) });
         }
         Box::pin(async { self.conn.as_mut().unwrap().ping().await })
     }
 
-    fn close(&mut self) -> BoxFuture<Result<(), Error>> {
+    fn close(&mut self) -> BoxFuture<'_, Result<(), Error>> {
         if self.conn.is_none() {
             return Box::pin(async { Err(Error::from("conn is drop")) });
         }
         Box::pin(async { self.conn.as_mut().unwrap().close().await })
+    }
+
+    fn begin(&mut self) -> BoxFuture<'_, Result<(), Error>> {
+        if self.conn.is_none() {
+            return Box::pin(async { Err(Error::from("conn is drop")) });
+        }
+        self.conn.as_mut().unwrap().begin()
+    }
+
+    fn commit(&mut self) -> BoxFuture<'_, Result<(), Error>> {
+        if self.conn.is_none() {
+            return Box::pin(async { Err(Error::from("conn is drop")) });
+        }
+        self.conn.as_mut().unwrap().commit()
+    }
+
+    fn rollback(&mut self) -> BoxFuture<'_, Result<(), Error>> {
+        if self.conn.is_none() {
+            return Box::pin(async { Err(Error::from("conn is drop")) });
+        }
+        self.conn.as_mut().unwrap().rollback()
     }
 }
 


### PR DESCRIPTION
Updated
  - rbs to 4.7
  - rbdc to 4.7
  - deadpool to 0.13

  - Imports updated: ConnectionManager/ConnectionGuard (for new public rbdc 4.7 API)
  - Timeouts initialization changed to struct literal with explicit recycle: None field (deadpool 0.13 API)
  - Added From<ConnectionManager> impl for ConnManagerProxy
  - Added begin, commit, rollback methods (for rbdc 4.7's Connection trait)
  - Replaced futures_core::future::BoxFuture with a local type alias using std — no new dependency
  - Replaced deprecated to_value! with value! throughout